### PR TITLE
Fix layout on doc pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,6 @@
 # Production settings
 
-baseurl: "/"
-url: "https://microservices-demo.github.io"
+baseurl: ""
 deploy_doc_url_prefix: https://microservices-demo.github.io/microservices-demo
 main_url_prefix: https://microservices-demo.github.io
 


### PR DESCRIPTION
Layout on https://microservices-demo.github.io/docs/ is broken. This PR sets the baseurl to `""`, to prevent the double slash in `//assets/css/custom.cs`, which tries to connect to a host named`assets`.
