### PR TITLE
add k8s cluster deployment

### DIFF
--- a/_includes/doc_menu.html
+++ b/_includes/doc_menu.html
@@ -14,7 +14,7 @@
   </li>
   <li><span>Kubernetes</span>
     <ul>
-      <li><a href="/microservices-demo/deployment/kubernetes-minikube.html">Any Kubernetes Cluster</a></li>
+      <li><a href="/microservices-demo/deployment/kubernetes-start.html">Any Kubernetes Cluster</a></li>
       <li><a href="/microservices-demo/deployment/kubernetes-minikube.html">Minikube</a></li>
       <li><a href="/microservices-demo/deployment/kubernetes.html">Kubernetes + Weave on AWS</a></li>
     </ul>

--- a/_includes/doc_menu.html
+++ b/_includes/doc_menu.html
@@ -14,8 +14,9 @@
   </li>
   <li><span>Kubernetes</span>
     <ul>
+      <li><a href="/microservices-demo/deployment/kubernetes-minikube.html">Any Kubernetes Cluster</a></li>
       <li><a href="/microservices-demo/deployment/kubernetes-minikube.html">Minikube</a></li>
-      <li><a href="/microservices-demo/deployment/kubernetes.html">Kubernetes + Weave</a></li>
+      <li><a href="/microservices-demo/deployment/kubernetes.html">Kubernetes + Weave on AWS</a></li>
     </ul>
   </li>
   <li>

--- a/deployment/kubernetes-start.md
+++ b/deployment/kubernetes-start.md
@@ -1,0 +1,24 @@
+---
+layout: default
+deployDoc: true
+---
+
+## Deploying Sock Shop on any Kubernetes cluster
+
+This explains how to deploy the Sock Shop onto any existing Kubernetes cluster.
+
+### Pre-requisites
+
+- Create a Kubernetes linux cluster.  For instance, see these examples:
+  - AWS - [KOPS](https://github.com/kubernetes/kops)
+  - Azure - [Azure Container Service](https://docs.microsoft.com/azure/container-service/container-service-kubernetes-walkthrough)
+  - Google Cloud - [Google Container Engine](https://cloud.google.com/container-engine/docs/clusters/operations)
+- Install and configure kubectl to connect to the cluster
+
+### Deploy Sock Shop
+
+1. [Clone the microservices-demo repository](https://github.com/microservices-demo/microservices-demo)
+1. Go to the *deploy/kubernetes* folder
+    ```
+    kubectl apply -f complete-demo.yaml
+    ```


### PR DESCRIPTION
Allows people to deploy the base socks shop to any kubernetes cluster (no provider-lock-in) like currently exists with the terraform deployment choice.