### PR TITLE
Fix link to kubectl in Minikube guide

### DIFF
--- a/deployment/kubernetes-minikube.md
+++ b/deployment/kubernetes-minikube.md
@@ -8,7 +8,7 @@ This demo demonstrates running the Sock Shop on Minikube.
 
 ### Pre-requisites
 * Install [Minikube](https://github.com/kubernetes/minikube)
-* Install [kubectl] (http://kubernetes.io/docs/user-guide/prereqs/)
+* Install [kubectl](http://kubernetes.io/docs/user-guide/prereqs/)
 
 ### Clone the microservices-demo repo 
 


### PR DESCRIPTION
What the title says. It's a minor fix. Link to kubectl on "Minikube deployment" guide was broken because of blank space.