### PR TITLE
Add monitoring instructions

### DIFF
--- a/_includes/doc_menu.html
+++ b/_includes/doc_menu.html
@@ -45,6 +45,7 @@
   <li><span>Monitoring</span>
     <ul>
       <li><a href="/microservices-demo/deployment/monitoring-kubernetes.html">Kubernetes</a></li>
+      <li><a href="/microservices-demo/deployment/monitoring-docker-compose.html">Docker Compose</a></li>
     </ul>
   </li>
 </ul>

--- a/_includes/doc_menu.html
+++ b/_includes/doc_menu.html
@@ -42,4 +42,9 @@
       <li><a href="/microservices-demo/deployment/apcera.html">Apcera</a></li>
     </ul>
   </li>
+  <li><span>Monitoring</span>
+    <ul>
+      <li><a href="/microservices-demo/deployment/monitoring-kubernetes.html">Kubernetes</a></li>
+    </ul>
+  </li>
 </ul>

--- a/deployment/monitoring-docker-compose.md
+++ b/deployment/monitoring-docker-compose.md
@@ -1,0 +1,57 @@
+---
+layout: default
+deployDoc: true
+---
+
+## Docker Compose
+
+> NOTE: All the commands listed on this guide must be ran from the root of the project.
+
+
+To deploy Prometheus & Grafana and to setup all the nice graphs that we got ready
+for you, simply:
+
+```
+$ docker-compose -f ./deploy/docker-compose/docker-compose.monitoring.yml up -d
+```
+
+Wait for the deployment to be ready. Check the status with
+
+```
+$ docker-compose -f ./deploy/docker-compose/docker-compose.monitoring.yml ps
+```
+
+### Importing The Dashboards
+
+You only need to do this once:
+
+```
+$ docker-compose \
+    -f ./deploy/docker-compose/docker-compose.monitoring.yml \
+    run \
+    --entrypoint /opt/grafana-import-dashboards/import.sh \
+    --rm \
+    importer
+```
+
+### Accessing The Services
+Once the services are up & running you can access them with the following URLs:
+
+  * Prometheus: <http://localhost:9090>
+  * Grafana: <http://localhost:3000>
+
+### Grafana Credentials
+<table class="user-creds">
+  <thead>
+    <tr>
+      <td>Username</td>
+      <td>Password</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>admin</td>
+      <td>foobar</td>
+    </tr>
+  </tbody>
+</table>

--- a/deployment/monitoring-kubernetes.md
+++ b/deployment/monitoring-kubernetes.md
@@ -1,0 +1,28 @@
+---
+layout: default
+deployDoc: true
+---
+
+## Kubernetes
+To deploy Prometheus & Grafana and to setup all the nice graphs that we got ready
+for you, simply:
+
+```
+$ kubectl create -f ./deploy/kubernetes/manifests-monitoring
+```
+
+Assuming that used `minikube` to deploy your Kubernetes cluster, to get the URL of
+the services:
+
+
+#### Prometheus
+```
+$ minikube service list | grep prometheus
+| monitoring  | prometheus           | http://192.168.99.100:31090 |
+```
+
+#### Grafana
+```
+$ minikube service list | grep grafana
+| monitoring  | grafana              | http://192.168.99.100:31300 |
+```


### PR DESCRIPTION
> NOTE: Waiting on https://github.com/microservices-demo/microservices-demo/pull/719 before this can be merged.

We updated the microservices demo so that users can deploy a full-blown graphing stack with Prometheus and Grafana. No instructions on how to do it yet, though.

So, this PR adds the documentation for deploying the monitoring solution (Prometheus, Grafana and built-in dashboards) to both Kubernetes and Docker Compose.