### PR TITLE
Remove Opentracing from Compose docs

### DIFF
--- a/deployment/docker-compose-weave.md
+++ b/deployment/docker-compose-weave.md
@@ -78,11 +78,6 @@ This will send some traffic to the application, which will form the connection g
 
 -->
 
-### Opentracing
-
-Zipkin is part of the deployment and has been written into some of the services.  While the system is up you can view the traces in
-Zipkin at http://localhost:9411.  Currently orders provide the most comprehensive traces.
-
 ### Cleaning up
 
 <!-- deploy-doc-start destroy-infrastructure -->

--- a/deployment/docker-compose.md
+++ b/deployment/docker-compose.md
@@ -78,11 +78,6 @@ This will send some traffic to the application, which will form the connection g
 
 -->
 
-### Opentracing
-Zipkin is part of the deployment and has been written into some of the services.  While the system is up you can view the traces in
-Zipkin at http://localhost:9411.  Currently orders provide the most comprehensive traces.
-
-
 ### Cleaning up
 
 <!-- deploy-doc-start destroy-infrastructure -->


### PR DESCRIPTION
It was removed from Compose demo in microservices-demo/microservices-demo#708
And there was no opentracing in Compose + Weave demo.

Signed-off-by: Elena Morozova <lelenanam@gmail.com>