### PR TITLE
Update Minikube Documentation

### DIFF
--- a/deployment/kubernetes-minikube.md
+++ b/deployment/kubernetes-minikube.md
@@ -22,7 +22,7 @@ cd microservices-demo
 You can start Minikube by running:
 
 ```
-minikube start --memory 8192
+minikube start --memory 8192 --cpus 4
 ```
 
 Check if it's running with `minikube status`, and make sure the Kubernetes dashboard is running on http://192.168.99.100:30000.


### PR DESCRIPTION
Add ``--cpus 4`` to the minikube start command

Without specifying 4 cpus or more, the sock shop will fail to deploy.

 See issue #79