### PR TITLE
Fixes duplicate namespace in minikube creation

### DIFF
--- a/deployment/kubernetes-minikube.md
+++ b/deployment/kubernetes-minikube.md
@@ -61,7 +61,7 @@ You should be able to see the Kibana dashboard at http://192.168.99.100:31601.
 Deploy the Sock Shop application on Minikube
 
 ```
-kubectl create -f deploy/kubernetes/manifests/sock-shop-ns.yaml -f deploy/kubernetes/manifests
+kubectl create -f deploy/kubernetes/manifests
 ```
 
 To start Opentracing run the following command after deploying the sock shop


### PR DESCRIPTION
Possibly due to previous refactoring (i.e. adding numeric prefixes),
the deployment now attempts to create the sock-shop namespace twice as
the `00-sock-shop-ns.yaml` is included explicitly as well as being
included implicitly in the `manifests` folder